### PR TITLE
Wrap lines based on word boundries

### DIFF
--- a/hfold.cabal
+++ b/hfold.cabal
@@ -19,7 +19,6 @@ executable hfold
   main-is:             src/Main.hs
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.8 && <4.9,
-                       text
+  build-depends:       base >=4.8 && <4.9
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,13 +1,16 @@
 main = putStrLn "It works!"
 
 wrap :: Int -> String -> [String]
-wrap n s = foldl (splitWordsAt n) [] . words $ s
+wrap n s = foldl (splitWordsAt n) [] $ words s
 
 splitWordsAt :: Int -> [String] -> String -> [String]
 splitWordsAt _ [] x = [x]
 splitWordsAt n xs x
-  | lineIsTooLong n (unwords [last xs, x]) = xs ++ [x]
-  | otherwise = init xs ++ [(unwords [last xs, x])]
+  | lineIsTooLong n (appendToLast xs x) = xs ++ [x]
+  | otherwise = init xs ++ [appendToLast xs x]
+
+appendToLast :: [String] -> String -> String
+appendToLast xs x = unwords [last xs, x]
 
 lineIsTooLong :: Int -> String -> Bool
 lineIsTooLong n xs = length xs > n

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -2,11 +2,22 @@ import qualified Data.Text as T (strip, pack, unpack)
 
 main = putStrLn "It works!"
 
-wrap :: String -> [String]
-wrap = map trim . combine . splitAt 80
+wrap :: Int -> String -> [String]
+wrap n s = removeEmpty . map trim . foldl (splitWordsAt n) [] . words $ s
 
-combine :: (a, a) -> [a]
-combine (a, b) = [a, b]
+splitWordsAt :: Int -> [String] -> String -> [String]
+splitWordsAt _ [] x = [x]
+splitWordsAt n xs x
+  | lineIsTooLong n (unwords [last xs, x]) = xs ++ [x]
+  | otherwise = init xs ++ [(unwords [last xs, x])]
+
+lineIsTooLong :: Int -> String -> Bool
+lineIsTooLong n xs = case length xs `compare` n of
+  GT -> True
+  otherwise -> False
 
 trim :: String -> String
 trim = T.unpack . T.strip . T.pack
+
+removeEmpty :: [[a]] -> [[a]]
+removeEmpty = filter (not . null)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,9 +1,7 @@
-import qualified Data.Text as T (strip, pack, unpack)
-
 main = putStrLn "It works!"
 
 wrap :: Int -> String -> [String]
-wrap n s = removeEmpty . map trim . foldl (splitWordsAt n) [] . words $ s
+wrap n s = foldl (splitWordsAt n) [] . words $ s
 
 splitWordsAt :: Int -> [String] -> String -> [String]
 splitWordsAt _ [] x = [x]
@@ -12,12 +10,4 @@ splitWordsAt n xs x
   | otherwise = init xs ++ [(unwords [last xs, x])]
 
 lineIsTooLong :: Int -> String -> Bool
-lineIsTooLong n xs = case length xs `compare` n of
-  GT -> True
-  otherwise -> False
-
-trim :: String -> String
-trim = T.unpack . T.strip . T.pack
-
-removeEmpty :: [[a]] -> [[a]]
-removeEmpty = filter (not . null)
+lineIsTooLong n xs = length xs > n


### PR DESCRIPTION
This makes line wrapping a little smarter. Instead of hard-wrapping on
80 (or however many) characters, we can wrap based on word boundries if
adding another word to the line pushes it past 80 (or however many)
characters.

This also makes the line length arbitrary.
