### PR TITLE
Allow users to pass options on the command line

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,16 +1,46 @@
-main = putStrLn "It works!"
+import Options.Applicative
 
-wrap :: Int -> String -> [String]
-wrap n s = foldl (splitWordsAt n) [] $ words s
+data Config = Config
+  { width :: Int
+  , path :: FilePath
+  }
+
+config :: Parser Config
+config = Config
+    <$> option auto
+        ( long "width"
+        <> short 'w'
+        <> metavar "WIDTH"
+        <> value 80
+        <> help "Specify a line width to use instead of the default 80 columns"
+        )
+
+    <*> argument str
+        ( metavar "PATH"
+        <> help "Path to input file"
+        )
+
+main :: IO ()
+main = execParser opts >>= run
+  where
+    opts = info (helper <*> config)
+      ( fullDesc
+      <> progDesc "Intelligently wrap lines to a given length"
+      )
+
+run :: Config -> IO ()
+run (Config w p) = do
+    f <- readFile p
+    putStrLn $ unlines $ wrapLine w =<< lines f
+
+wrapLine :: Int -> String -> [String]
+wrapLine w s = foldl (splitWordsAt w) [] $ words s
 
 splitWordsAt :: Int -> [String] -> String -> [String]
 splitWordsAt _ [] x = [x]
-splitWordsAt n xs x
-  | lineIsTooLong n (appendToLast xs x) = xs ++ [x]
+splitWordsAt w xs x
+  | length (appendToLast xs x) > w = xs ++ [x]
   | otherwise = init xs ++ [appendToLast xs x]
 
 appendToLast :: [String] -> String -> String
 appendToLast xs x = unwords [last xs, x]
-
-lineIsTooLong :: Int -> String -> Bool
-lineIsTooLong n xs = length xs > n


### PR DESCRIPTION
Users can now pass their desired width as well as the path of the file
that contains text to wrap as command line arguments. The width defaults
to 80, and the path is required.

I still need to figure out how to accept text on STDIN if the path isn't
provided, but we'll get there.

There's also a bit of refactoring going on in here, but this is the real
meat of what I was trying to accomplish.

This adds optparse-applicative as a dependency (which I apparently
_accidentally_ added into the cabal file on master earlier. Oops).
