### PR TITLE
Accept input on STDIN

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -17,7 +17,8 @@ config = Config
 
     <*> argument str
         ( metavar "PATH"
-        <> help "Path to input file"
+        <> help "Path to input file. If not provided, hfold will attempt to read from STDIN"
+        <> value "-"
         )
 
 main :: IO ()
@@ -30,8 +31,12 @@ main = execParser opts >>= run
 
 run :: Config -> IO ()
 run (Config w p) = do
-    f <- readFile p
-    putStrLn $ unlines $ wrapLine w =<< lines f
+    c <- contentsOrSTDIN p
+    putStrLn $ unlines $ wrapLine w =<< lines c
+
+contentsOrSTDIN :: String -> IO String
+contentsOrSTDIN "-" = getContents
+contentsOrSTDIN p = readFile p
 
 wrapLine :: Int -> String -> [String]
 wrapLine w s = foldl (splitWordsAt w) [] $ words s


### PR DESCRIPTION
In addition to being able to pass a file path on the commandline, it
would be nice to be able to also accept input on STDIN.

To do this, we're adding a default value of `-` to represent STDIN for
the file path argument. If the file path is set to `-`, we'll read from
STDIN. Otherwise, we'll read from the provided file path.

Fixes #6

h/t @pbrisbin for helping me think through this
