### PR TITLE
Don't throw away empty lines

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -39,6 +39,7 @@ contentsOrSTDIN "-" = getContents
 contentsOrSTDIN p = readFile p
 
 wrapLine :: Int -> String -> [String]
+wrapLine _ [] = [""]
 wrapLine w s = foldl (splitWordsAt w) [] $ words s
 
 splitWordsAt :: Int -> [String] -> String -> [String]


### PR DESCRIPTION
Previously, calling `wrapLine _ ""` would result in `[]` being returned,
which meant that empty lines were removed from the output. This isn't
intended, and we should instead make sure to preserve these empty lines
by explicitly returning them properly.

Fixes #4
