### PR TITLE
Wrap content differently based on type

### DIFF
--- a/hfold.cabal
+++ b/hfold.cabal
@@ -15,4 +15,6 @@ executable hfold
                   ,  optparse-applicative
                   ,  text
 
+  other-modules:     Hfold.CLI
+
   default-language:  Haskell2010

--- a/hfold.cabal
+++ b/hfold.cabal
@@ -16,5 +16,6 @@ executable hfold
                   ,  text
 
   other-modules:     Hfold.CLI
+                   , Hfold.Types
 
   default-language:  Haskell2010

--- a/hfold.cabal
+++ b/hfold.cabal
@@ -12,10 +12,12 @@ executable hfold
   hs-source-dirs:    src
   main-is:           Main.hs
   build-depends:     base >=4.8 && <4.9
-                  ,  optparse-applicative
-                  ,  text
+                   , optparse-applicative
+                   , text
+                   , parsec
 
   other-modules:     Hfold.CLI
+                   , Hfold.Parser
                    , Hfold.Types
 
   default-language:  Haskell2010

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -6,6 +6,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
+import Hfold.Types
 import Hfold.CLI
 
 main :: IO ()

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,25 +1,31 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Options.Applicative (execParser)
-import Data.Char (isSpace)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
 import Hfold.Types
 import Hfold.CLI
+import Hfold.Parser
 
 main :: IO ()
 main = execParser opts >>= run
 
 run :: Config -> IO ()
-run (Config w p) = do
-    c <- contentsOrSTDIN p
-    T.putStrLn $ T.stripEnd $ T.unlines $ wrapLine w =<< T.lines c
+run (Config w p) = T.putStrLn . wrap w . parseFile =<< contentsOrSTDIN p
 
 contentsOrSTDIN :: FilePath -> IO Text
 contentsOrSTDIN "-" = T.getContents
 contentsOrSTDIN p = T.readFile p
+
+wrap :: Int -> [Content] -> Text
+wrap w = T.stripEnd . T.unlines . concatMap (wrapContent w)
+
+wrapContent :: Int -> Content -> [Text]
+wrapContent _ (CodeBlock t) = [t]
+wrapContent _ (Quoted t) = [t]
+wrapContent w (Normal t) = wrapLine w t
 
 wrapLine :: Int -> Text -> [Text]
 wrapLine _ "" = [""]

--- a/src/hfold/CLI.hs
+++ b/src/hfold/CLI.hs
@@ -2,10 +2,7 @@ module Hfold.CLI where
 
 import Options.Applicative
 
-data Config = Config
-  { width :: Int
-  , path :: FilePath
-  }
+import Hfold.Types
 
 opts :: ParserInfo Config
 opts = info (helper <*> config)

--- a/src/hfold/Parser.hs
+++ b/src/hfold/Parser.hs
@@ -8,9 +8,7 @@ import Text.ParserCombinators.Parsec
 import Hfold.Types
 
 parseFile :: Text -> [Content]
-parseFile t = case parse parseContent "content" (T.unpack t) of
-    Left err -> []
-    Right xs -> xs
+parseFile t = either (const []) id $ parse parseContent "content" (T.unpack t)
 
 parseContent :: Parser [Content]
 parseContent = many (quoted <|> codeBlock <|> normal) <* eof

--- a/src/hfold/Parser.hs
+++ b/src/hfold/Parser.hs
@@ -1,0 +1,55 @@
+module Hfold.Parser where
+
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import qualified Data.Text as T
+import Text.ParserCombinators.Parsec
+
+import Hfold.Types
+
+parseFile :: Text -> [Content]
+parseFile t = case parse parseContent "content" (T.unpack t) of
+    Left err -> []
+    Right xs -> xs
+
+parseContent :: Parser [Content]
+parseContent = do
+    c <- many (quoted <|> codeBlock <|> normal)
+    eof
+    return c
+
+normal :: Parser Content
+normal = Normal <$> singleLine
+
+quoted :: Parser Content
+quoted = do
+    q <- quoteChar
+    l <- singleLine
+    return $ Quoted (q <> l)
+
+codeBlock :: Parser Content
+codeBlock = do
+    s <- codeBlockChar
+    c <- codeBlockContents
+    e <- codeBlockChar
+    eol
+    return $ CodeBlock $ s <> c <> e
+
+singleLine :: Parser Text
+singleLine = T.pack <$> manyTill anyChar (try eol)
+
+quoteChar :: Parser Text
+quoteChar = T.pack <$> (string ">")
+
+codeBlockChar :: Parser Text
+codeBlockChar = T.pack <$> (string "```")
+
+codeBlockContents :: Parser Text
+codeBlockContents = T.pack <$> manyTill anyChar (lookAhead codeBlockChar)
+
+eol :: Parser String
+eol = try (string "\n\r")
+    <|> try (string "\r\n")
+    <|> string "\n"
+    <|> string "\r"
+    <?> "end of line"

--- a/src/hfold/Parser.hs
+++ b/src/hfold/Parser.hs
@@ -13,10 +13,7 @@ parseFile t = case parse parseContent "content" (T.unpack t) of
     Right xs -> xs
 
 parseContent :: Parser [Content]
-parseContent = do
-    c <- many (quoted <|> codeBlock <|> normal)
-    eof
-    return c
+parseContent = many (quoted <|> codeBlock <|> normal) <* eof
 
 normal :: Parser Content
 normal = Normal <$> singleLine

--- a/src/hfold/Types.hs
+++ b/src/hfold/Types.hs
@@ -1,6 +1,10 @@
 module Hfold.Types where
 
+import Data.Text (Text)
+
 data Config = Config
   { width :: Int
   , path :: FilePath
   }
+
+data Content = Normal Text | Quoted Text | CodeBlock Text deriving (Show)

--- a/src/hfold/Types.hs
+++ b/src/hfold/Types.hs
@@ -1,0 +1,6 @@
+module Hfold.Types where
+
+data Config = Config
+  { width :: Int
+  , path :: FilePath
+  }


### PR DESCRIPTION
We have 3 basic types of content in our files:
- Normal lines are basic text and should be wrapped at the specified
  width.
- Code blocks are surrounded by triple back-ticks and should be passed
  through unaltered.
- Quoted lines are prefixed with `>` and should be passed through
  unaltered. Eventually, we'll want to re-wrap these as well and
  re-prefix with `>`.

In order to do this, we can use Parsec to parse our file into our new
Content type, which describes these different content types. Once we have
those content types parsed out, we can pass the resulting
`[Content]` into a function that understands how to wrap different kinds of
content.
