### PR TITLE
Add the ability to conditionally wrap headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,25 @@
 # reflow
 
-A smarter `fold(1)`, written in Haskell.
+Intelligently reflow text to a given length.
+
+`reflow` is like `fold(1)` on steroids:
+
+ - Break lines on word boundaries by default (mimicking `fold -s`)
+ - Doesn't reflow markdown code blocks
+ - Doesn't reflow markdown/email quote blocks
+ - Optionally doesn't reflow email headers
 
 ## Usage
 
 ```
-Usage: reflow [-w|--width WIDTH] [PATH]
-  Intelligently wrap lines to a given length
+Usage: reflow [-w|--width WIDTH] [--ignore-headers] [PATH]
+  Intelligently reflow text to a given length
 
 Available options:
   -h,--help                Show this help text
   -w,--width WIDTH         Specify a line width to use instead of the default 80
                            columns
+  --ignore-headers         Don't wrap email headers
   PATH                     Path to input file. If not provided, reflow will
                            attempt to read from STDIN
 ```

--- a/reflow.cabal
+++ b/reflow.cabal
@@ -1,6 +1,6 @@
 name:                    reflow
 version:                 1.0.0
-synopsis:                This is a synopsis
+synopsis:                Intelligently reflow text with a given line length
 license:                 MIT
 license-file:            LICENSE
 author:                  Gordon Fontenot

--- a/reflow.cabal
+++ b/reflow.cabal
@@ -1,23 +1,25 @@
-name:                reflow
-version:             1.0.0
-synopsis:            This is a synopsis
-license:             MIT
-license-file:        LICENSE
-author:              Gordon Fontenot
-maintainer:          gordon@fonten.io
-build-type:          Simple
-cabal-version:       >=1.10
+name:                    reflow
+version:                 1.0.0
+synopsis:                This is a synopsis
+license:                 MIT
+license-file:            LICENSE
+author:                  Gordon Fontenot
+maintainer:              gordon@fonten.io
+build-type:              Simple
+cabal-version:           >=1.10
 
 executable reflow
-  hs-source-dirs:    src
-  main-is:           Main.hs
-  build-depends:     base >=4.8 && <4.9
-                   , optparse-applicative
-                   , text
-                   , parsec
+  hs-source-dirs:        src
+  ghc-options:           -Wall
+  main-is:               Main.hs
+  build-depends:         base >=4.8 && <4.9
+                       , optparse-applicative
+                       , text
+                       , parsec
 
-  other-modules:     Reflow.CLI
-                   , Reflow.Parser
-                   , Reflow.Types
+  other-modules:         Reflow.CLI
+                       , Reflow.Parser
+                       , Reflow.Types
 
-  default-language:  Haskell2010
+  default-language:      Haskell2010
+  default-extensions:    OverloadedStrings

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,20 +11,22 @@ main :: IO ()
 main = execParser opts >>= run
 
 run :: Config -> IO ()
-run (Config w p) = T.putStrLn . wrap w . parseFile =<< contentsOrSTDIN p
+run c@(Config _ _ p) = T.putStrLn . wrap c . parseFile =<< contentsOrSTDIN p
 
 contentsOrSTDIN :: FilePath -> IO Text
 contentsOrSTDIN "-" = T.getContents
 contentsOrSTDIN p = T.readFile p
 
-wrap :: Int -> [Content] -> Text
-wrap w = T.stripEnd . T.unlines . concatMap (wrapContent w)
+wrap :: Config -> [Content] -> Text
+wrap c = T.stripEnd . T.unlines . concatMap (wrapContent c)
 
-wrapContent :: Int -> Content -> [Text]
-wrapContent _ (CodeBlock t) = [t]
-wrapContent _ (Quoted t) = [t]
-wrapContent _ (Header t) = [t]
-wrapContent w (Normal t) = wrapLine w t
+wrapContent :: Config -> Content -> [Text]
+wrapContent _              (CodeBlock t) = [t]
+wrapContent _              (Quoted t) = [t]
+wrapContent (Config w _ _) (Normal t) = wrapLine w t
+wrapContent (Config w i _) (Header t)
+    | i = [t]
+    | otherwise = wrapLine w t
 
 wrapLine :: Int -> Text -> [Text]
 wrapLine _ "" = [""]

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 import Options.Applicative (execParser)
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -23,6 +23,7 @@ wrap w = T.stripEnd . T.unlines . concatMap (wrapContent w)
 wrapContent :: Int -> Content -> [Text]
 wrapContent _ (CodeBlock t) = [t]
 wrapContent _ (Quoted t) = [t]
+wrapContent _ (Header t) = [t]
 wrapContent w (Normal t) = wrapLine w t
 
 wrapLine :: Int -> Text -> [Text]

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,7 +11,7 @@ main :: IO ()
 main = execParser opts >>= run
 
 run :: Config -> IO ()
-run c@(Config _ _ p) = T.putStrLn . wrap c . parseFile =<< contentsOrSTDIN p
+run c = T.putStrLn . wrap c . parseFile =<< contentsOrSTDIN (path c)
 
 contentsOrSTDIN :: FilePath -> IO Text
 contentsOrSTDIN "-" = T.getContents
@@ -21,12 +21,12 @@ wrap :: Config -> [Content] -> Text
 wrap c = T.stripEnd . T.unlines . concatMap (wrapContent c)
 
 wrapContent :: Config -> Content -> [Text]
-wrapContent _              (CodeBlock t) = [t]
-wrapContent _              (Quoted t) = [t]
-wrapContent (Config w _ _) (Normal t) = wrapLine w t
-wrapContent (Config w i _) (Header t)
-    | i = [t]
-    | otherwise = wrapLine w t
+wrapContent _ (CodeBlock t) = [t]
+wrapContent _ (Quoted t) = [t]
+wrapContent c (Normal t) = wrapLine (width c) t
+wrapContent c (Header t)
+    | ignoreHeaders c = [t]
+    | otherwise = wrapLine (width c) t
 
 wrapLine :: Int -> Text -> [Text]
 wrapLine _ "" = [""]

--- a/src/Reflow/CLI.hs
+++ b/src/Reflow/CLI.hs
@@ -20,6 +20,11 @@ config = Config
         <> help "Specify a line width to use instead of the default 80 columns"
         )
 
+    <*> switch
+        ( long "ignore-headers"
+        <> help "Don't wrap email headers"
+        )
+
     <*> argument str
         ( metavar "PATH"
         <> help "Path to input file. If not provided, reflow will attempt to read from STDIN"

--- a/src/Reflow/CLI.hs
+++ b/src/Reflow/CLI.hs
@@ -7,7 +7,7 @@ import Reflow.Types
 opts :: ParserInfo Config
 opts = info (helper <*> config)
   ( fullDesc
-  <> progDesc "Intelligently wrap lines to a given length"
+  <> progDesc "Intelligently reflow text to a given length"
   )
 
 config :: Parser Config

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -17,7 +17,7 @@ parseContent = do
     h <- option [] (many header)
     c <- many (quoted <|> codeBlock <|> normal)
     void eof
-    return (h <> c)
+    return $ h <> c
 
 normal :: Parser Content
 normal = Normal <$> singleLine

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -23,19 +23,21 @@ normal = Normal <$> singleLine
 
 header :: Parser Content
 header = do
-    name <- many1 $ noneOf ":\n"
-    start <- many1 $ noneOf "\n"
-    void newline
-    rest <- many headerContinued
-    let value = T.pack start <> "\n" <> T.unlines rest
-    return $ Header $ T.pack name <> value
+    n <- headerName
+    s <- singleLine
+    r <- many headerContinued
+    let v = s <> T.unlines r
+    return $ Header $ n <> v
+
+headerName :: Parser Text
+headerName = T.pack <$> (many1 $ noneOf ":\n")
 
 headerContinued :: Parser Text
 headerContinued = do
-    void $ char '\t'
-    text <- many1 $ noneOf "\n"
-    void newline
-    return $ "\t" <> T.pack text <> "\n"
+    void tab
+    text <- singleLine
+    void eol
+    return $ "\t" <> text <> "\n"
 
 quoted :: Parser Content
 quoted = do

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -3,6 +3,7 @@ module Reflow.Parser where
 import Control.Monad (void)
 import Data.Monoid ((<>))
 import Data.Text (Text, pack)
+import qualified Data.Text as T
 import Text.Parsec
 import Text.Parsec.Text (Parser)
 
@@ -30,7 +31,7 @@ header = do
     return $ Header $ n <> v
 
 headerName :: Parser Text
-headerName = T.pack <$> (many1 $ noneOf ":\n")
+headerName = pack <$> (many1 $ noneOf ":\n")
 
 headerContinued :: Parser Text
 headerContinued = do

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -1,5 +1,6 @@
 module Reflow.Parser where
 
+import Control.Monad (void)
 import Data.Monoid ((<>))
 import Data.Text (Text, pack)
 import Text.Parsec
@@ -11,10 +12,30 @@ parseFile :: Text -> [Content]
 parseFile t = either (const []) id $ parse parseContent "content" t
 
 parseContent :: Parser [Content]
-parseContent = many (quoted <|> codeBlock <|> normal) <* eof
+parseContent = do
+    h <- option [] (many header)
+    c <- many (quoted <|> codeBlock <|> normal)
+    void eof
+    return (h <> c)
 
 normal :: Parser Content
 normal = Normal <$> singleLine
+
+header :: Parser Content
+header = do
+    name <- many1 $ noneOf ":\n"
+    start <- many1 $ noneOf "\n"
+    void newline
+    rest <- many headerContinued
+    let value = T.pack start <> "\n" <> T.unlines rest
+    return $ Header $ T.pack name <> value
+
+headerContinued :: Parser Text
+headerContinued = do
+    void $ char '\t'
+    text <- many1 $ noneOf "\n"
+    void newline
+    return $ "\t" <> T.pack text <> "\n"
 
 quoted :: Parser Content
 quoted = do
@@ -27,7 +48,7 @@ codeBlock = do
     s <- codeBlockChar
     c <- codeBlockContents
     e <- codeBlockChar
-    eol
+    void eol
     return $ CodeBlock $ s <> c <> e
 
 singleLine :: Parser Text

--- a/src/Reflow/Types.hs
+++ b/src/Reflow/Types.hs
@@ -7,4 +7,5 @@ data Config = Config
   , path :: FilePath
   }
 
-data Content = Normal Text | Quoted Text | CodeBlock Text deriving (Show)
+data Content = Normal Text | Header Text | Quoted Text | CodeBlock Text
+    deriving (Show)

--- a/src/Reflow/Types.hs
+++ b/src/Reflow/Types.hs
@@ -4,6 +4,7 @@ import Data.Text (Text)
 
 data Config = Config
   { width :: Int
+  , ignoreHeaders :: Bool
   , path :: FilePath
   }
 


### PR DESCRIPTION
When wrapping an email, it'd be nice to be able to tell `reflow` to not wrap
headers. These are usually formatted with a specific intent in mind, and it's
best not to fuck with that. We assume users are _not_ parsing emails, and so
wrap headers like any other text content, but if users would like, they can
pass a flag (`--ignore-headers`) on the command line and leave the headers
alone while wrapping.
