### PR TITLE
Fix optional headers

### DIFF
--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -31,7 +31,10 @@ header = do
     return $ Header $ n <> v
 
 headerName :: Parser Text
-headerName = pack <$> (many1 $ noneOf ":\n")
+headerName = do
+    n <- manyTill (noneOf "\n") (lookAhead $ string ":")
+    s <- string ":"
+    return $ pack $ n <> s
 
 headerContinued :: Parser Text
 headerContinued = do

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -31,10 +31,12 @@ header = do
     return $ Header $ n <> v
 
 headerName :: Parser Text
-headerName = do
-    n <- manyTill (noneOf "\n") (lookAhead $ string ":")
-    s <- string ":"
-    return $ pack $ n <> s
+headerName = fmap pack $ mappend
+    <$> many1 allowedHeaderChars
+    <*> string ":"
+
+allowedHeaderChars :: Parser Char
+allowedHeaderChars = alphaNum <|> char '-'
 
 headerContinued :: Parser Text
 headerContinued = do

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -14,7 +14,7 @@ parseFile t = either (const []) id $ parse parseContent "content" t
 
 parseContent :: Parser [Content]
 parseContent = do
-    h <- option [] (many header)
+    h <- option [] (try $ many header)
     c <- many (quoted <|> codeBlock <|> normal)
     void eof
     return $ h <> c


### PR DESCRIPTION
- Improve header parsing for fewer false positives
- Use `option` properly (with `try`) so that the default is returned if
  parsing fails.
