### PR TITLE
Wrap quoted lines

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -22,7 +22,7 @@ wrap c = T.stripEnd . T.unlines . concatMap (wrapContent c)
 
 wrapContent :: Config -> Content -> [Text]
 wrapContent _ (CodeBlock t) = [t]
-wrapContent _ (Quoted t) = [t]
+wrapContent c (Quoted t) = map (mappend "> ") $ wrapLine (width c - 2) t
 wrapContent c (Normal t) = wrapLine (width c) t
 wrapContent c (Header t)
     | ignoreHeaders c = [t]

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -61,7 +61,7 @@ singleLine = pack <$> manyTill anyChar (try eol)
 
 quotePrefix :: Parser Text
 quotePrefix = fmap pack $ mappend
-    <$> (string ">")
+    <$> string ">"
     <*> (many $ char ' ')
 
 codeBlockChar :: Parser Text

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -46,10 +46,7 @@ headerContinued = do
     return $ "\t" <> text <> "\n"
 
 quoted :: Parser Content
-quoted = do
-    q <- quoteChar
-    l <- singleLine
-    return $ Quoted (q <> l)
+quoted = Quoted <$> (quotePrefix *> singleLine)
 
 codeBlock :: Parser Content
 codeBlock = do
@@ -62,8 +59,10 @@ codeBlock = do
 singleLine :: Parser Text
 singleLine = pack <$> manyTill anyChar (try eol)
 
-quoteChar :: Parser Text
-quoteChar = pack <$> (string ">")
+quotePrefix :: Parser Text
+quotePrefix = fmap pack $ mappend
+    <$> (string ">")
+    <*> (many $ char ' ')
 
 codeBlockChar :: Parser Text
 codeBlockChar = pack <$> (string "```")


### PR DESCRIPTION
Quoted lines can't just be hard wrapped, instead we need to take the quote
itself into account. This makes wrapping (single level) quoted lines possible
by:
1. Not capturing the quote character or any leading whitespace when parsing
   quoted lines
2. Wrapping a quoted line at the specified length - 2 to make room for quote
   char and a single space
3. Prepending each wrapped line with `"> "` to preserve the quote format.

Note that this _doesn't_ yet wrap nested quotes properly yet. I want to add
some tests for what I've got now before tackling that.
