### PR TITLE
Fix the parsing of multi-line headers

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,21 @@
+machine:
+  pre:
+    # https://github.com/commercialhaskell/stack/issues/1658
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 20
+    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.6 20
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 10
+    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 10
+
+dependencies:
+  pre:
+    - wget https://github.com/commercialhaskell/stack/releases/download/v0.1.6.0/stack-0.1.6.0-linux-x86_64.tar.gz -O /tmp/stack.tar.gz
+    - tar xvzOf /tmp/stack.tar.gz stack-0.1.6.0-linux-x86_64/stack > /tmp/stack
+    - chmod +x /tmp/stack && sudo mv /tmp/stack /usr/bin/stack
+  override:
+    - ./bin/setup
+  cache_directories:
+    - "~/.stack"
+
+test:
+  override:
+    - bin/test

--- a/fixtures/expected.txt
+++ b/fixtures/expected.txt
@@ -1,4 +1,6 @@
 Header: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+To: foo@example.com, bar@example.com, baz@example.com, quz@example.com, foobar@example.com, foobaz@example.com,
+	foobuzz@example.com, fooquz@example.com, bonk@example.com, bink@example.com, bank@example.com, bossman@example.com
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis

--- a/fixtures/input.txt
+++ b/fixtures/input.txt
@@ -1,4 +1,6 @@
 Header: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+To: foo@example.com, bar@example.com, baz@example.com, quz@example.com, foobar@example.com, foobaz@example.com,
+	foobuzz@example.com, fooquz@example.com, bonk@example.com, bink@example.com, bank@example.com, bossman@example.com
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -3,7 +3,6 @@ module Reflow.Parser where
 import Control.Monad (void)
 import Data.Monoid ((<>))
 import Data.Text (Text, pack)
-import qualified Data.Text as T
 import Text.Parsec
 import Text.Parsec.Text (Parser)
 
@@ -27,7 +26,7 @@ header = do
     n <- headerName
     s <- singleLine
     r <- many headerContinued
-    let v = s <> T.unlines r
+    let v = s <> foldl mappend "" r
     return $ Header $ n <> v
 
 headerName :: Parser Text
@@ -42,8 +41,7 @@ headerContinued :: Parser Text
 headerContinued = do
     void tab
     text <- singleLine
-    void eol
-    return $ "\t" <> text <> "\n"
+    return $ "\n\t" <> text
 
 quoted :: Parser Content
 quoted = Quoted <$> (quotePrefix *> singleLine)

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -26,7 +26,7 @@ header = do
     n <- headerName
     s <- singleLine
     r <- many headerContinued
-    let v = s <> foldl mappend "" r
+    let v = s <> mconcat r
     return $ Header $ n <> v
 
 headerName :: Parser Text


### PR DESCRIPTION
Because `singleLine` actually swallows the `eol` already, our
`headerContinued` parser was actually matching text like the following:

```
    foo bar baz

foo bar baz
```

This wasn't intentional, and resulted in parser failures when parsing
files with multi-line headers. Instead, we should only parse to the end
of the tabbed line (which is what `singleLine` does by default)

We were also adding a newline to the end of the `headerContinued`
result, which didn't actually make sense since that is added by the
concatenation that happens when we reconstitute the continued header.
Instead, we want to add a newline to the beginning of the continued
header, since that character is being thrown away when grabbing the
previous line.

In addition, since `unlines` adds a trailing newline, using it as a part
of our parser resulted in an extra newline being added between the
headers and the body text. Using `foldl mappend ""` doesn't add this
extra newline and means that our headers stay formatted the way we
expect.
