### PR TITLE
Allow code block parsing to fail

### DIFF
--- a/fixtures/expected.txt
+++ b/fixtures/expected.txt
@@ -26,3 +26,5 @@ func Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tem
     nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 }
 ```
+
+`foo` `bar` `baz`

--- a/fixtures/input.txt
+++ b/fixtures/input.txt
@@ -16,3 +16,5 @@ func Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tem
     nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 }
 ```
+
+`foo` `bar` `baz`

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -14,7 +14,7 @@ parseFile t = either (const []) id $ parse parseContent "content" t
 parseContent :: Parser [Content]
 parseContent = do
     h <- option [] (try $ many header)
-    c <- many (quoted <|> codeBlock <|> normal)
+    c <- many (quoted <|> try codeBlock <|> normal)
     void eof
     return $ h <> c
 


### PR DESCRIPTION
Previously, if a line started with backtick and didn't signal the start of a
code block, parsing would fail but would still consume input. This would
mean that `<|>` would result in an error instead of falling back to
parsing a `Normal` line of content.

To fix this, we should use `try` to ensure that parsing `codeBlock`
content fails without consuming content.
