### PR TITLE
Rewrap nested codeblocks

### DIFF
--- a/fixtures/expected.txt
+++ b/fixtures/expected.txt
@@ -20,6 +20,11 @@ in culpa qui officia deserunt mollit anim id est laborum."
 > quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 > consequat.
 
+> > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+> > tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+> > veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+> > commodo consequat.
+
 ```code
 func Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt {
     ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis

--- a/fixtures/input.txt
+++ b/fixtures/input.txt
@@ -10,6 +10,8 @@ Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu 
 
 >     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
+> > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
 ```code
 func Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt {
     ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -22,7 +22,7 @@ wrap c = T.stripEnd . T.unlines . concatMap (wrapContent c)
 
 wrapContent :: Config -> Content -> [Text]
 wrapContent _ (CodeBlock t) = [t]
-wrapContent c (Quoted t) = map (mappend "> ") $ wrapLine (width c - 2) t
+wrapContent c (Quoted t) = map (mappend "> ") $ wrapContent (lessWidth 2 c) t
 wrapContent c (Normal t) = wrapLine (width c) t
 wrapContent c (Header t)
     | ignoreHeaders c = [t]

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -44,7 +44,7 @@ headerContinued = do
     return $ "\n\t" <> text
 
 quoted :: Parser Content
-quoted = Quoted <$> (quotePrefix *> singleLine)
+quoted = Quoted <$> (quotePrefix *> (quoted <|> normal))
 
 codeBlock :: Parser Content
 codeBlock = do

--- a/src/Reflow/Types.hs
+++ b/src/Reflow/Types.hs
@@ -8,5 +8,8 @@ data Config = Config
   , path :: FilePath
   }
 
-data Content = Normal Text | Header Text | Quoted Text | CodeBlock Text
+lessWidth :: Int -> Config -> Config
+lessWidth i c = c { width = width c - i }
+
+data Content = Normal Text | Header Text | Quoted Content | CodeBlock Text
     deriving (Show)


### PR DESCRIPTION
Previously, wrapping nested codeblocks that looked like:

```
> > foo bar baz quz
```

would result in output that looked like:

```
> > foo bar
> baz quz
```

Now, by making `Quoted` recursive so that it holds onto `Content`
instead of `Text`, we can actually make `wrapContent` for `Quoted`
recursive as well, dropping the expected length by 2 and prepending
`"> "` for each recursion.

As a result, we're able to keep the quote level accurate and we end up
with output that looks like:

```
> > foo bar
> > baz quz
```

:tada:
