### PR TITLE
Improve error messaging

### DIFF
--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -8,8 +8,19 @@ import Text.Parsec.Text (Parser)
 
 import Reflow.Types
 
+parserError :: Text -> ParseError -> Content
+parserError input e = Normal
+    $ input
+    <> "\n\n\n"
+    <> "Warning: reflow parser failed\n"
+    <> (pack $ show e)
+
 parseFile :: Text -> [Content]
-parseFile t = either (const []) id $ parse parseContent "content" t
+parseFile t = do
+    let result = parse parseContent "content" t
+    case result of
+        Left e -> return $ parserError t e
+        Right success -> success
 
 parseContent :: Parser [Content]
 parseContent = do

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -16,11 +16,8 @@ parserError input e = Normal
     <> (pack $ show e)
 
 parseFile :: Text -> [Content]
-parseFile t = do
-    let result = parse parseContent "content" t
-    case result of
-        Left e -> return $ parserError t e
-        Right success -> success
+parseFile t = either (return . parserError t) id
+    $ parse parseContent "content" t
 
 parseContent :: Parser [Content]
 parseContent = do


### PR DESCRIPTION
Previously, when the parser failed, we were returning an empty list.
This... wasn't ideal, since it meant that I'd end up with a completely
blank email that I couldn't read.

Instead, what we should do, is to print the original text along with the
error message. This will help track down bugs during normal usage without
completely breaking my email if something isn't working quite right.
