### PR TITLE
Don't reflow PGP blocks in Mutt

### DIFF
--- a/fixtures/expected.txt
+++ b/fixtures/expected.txt
@@ -33,3 +33,12 @@ func Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tem
 ```
 
 `foo` `bar` `baz`
+
+[-- Begin signature information --]
+Good signature from: Gordon Fontenot (personal) <gordon@fonten.io>
+                aka: keybase.io/gfontenot <gfontenot@keybase.io>
+                aka: Gordon Fontenot (thoughtbot) <gordon@thoughtbot.com>
+                aka: Gordon Fontenot (personal) <gordon.fontenot@me.com>
+                aka: Gordon Fontenot (git) <gmoney@gitpushgitpaid.com>
+            created: Thu May 12 14:26:06 2016
+[-- End signature information --]

--- a/fixtures/input.txt
+++ b/fixtures/input.txt
@@ -20,3 +20,12 @@ func Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tem
 ```
 
 `foo` `bar` `baz`
+
+[-- Begin signature information --]
+Good signature from: Gordon Fontenot (personal) <gordon@fonten.io>
+                aka: keybase.io/gfontenot <gfontenot@keybase.io>
+                aka: Gordon Fontenot (thoughtbot) <gordon@thoughtbot.com>
+                aka: Gordon Fontenot (personal) <gordon.fontenot@me.com>
+                aka: Gordon Fontenot (git) <gmoney@gitpushgitpaid.com>
+            created: Thu May 12 14:26:06 2016
+[-- End signature information --]

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -22,6 +22,7 @@ wrap c = T.stripEnd . T.unlines . concatMap (wrapContent c)
 
 wrapContent :: Config -> Content -> [Text]
 wrapContent _ (CodeBlock t) = [t]
+wrapContent _ (PGPBlock t) = [t]
 wrapContent c (Quoted t) = map (mappend "> ") $ wrapContent (lessWidth 2 c) t
 wrapContent c (Normal t) = wrapLine (width c) t
 wrapContent c (Header t)

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -63,11 +63,10 @@ codeBlock = do
     return $ CodeBlock $ s <> c <> e
 
 pgpBlock :: Parser Content
-pgpBlock = do
-    s <- pgpBlockStart
-    c <- pgpBlockContents
-    e <- pgpBlockEnd
-    return $ PGPBlock $ s <> c <> e
+pgpBlock = fmap PGPBlock $ mappend3 <$> pgpBlockStart <*> pgpBlockContents <*> pgpBlockEnd
+
+mappend3 :: (Monoid m) => m -> m -> m -> m
+mappend3 a b c = a <> b <> c
 
 singleLine :: Parser Text
 singleLine = pack <$> manyTill anyChar (try eol)

--- a/src/Reflow/Types.hs
+++ b/src/Reflow/Types.hs
@@ -11,5 +11,5 @@ data Config = Config
 lessWidth :: Int -> Config -> Config
 lessWidth i c = c { width = width c - i }
 
-data Content = Normal Text | Header Text | Quoted Content | CodeBlock Text
+data Content = Normal Text | Header Text | Quoted Content | CodeBlock Text | PGPBlock Text
     deriving (Show)


### PR DESCRIPTION
Fixes #29.

Please check this in Mutt to make sure it works as expected.
