### PR TITLE
Don't add extra newline info to pgp blocks

### DIFF
--- a/fixtures/expected.txt
+++ b/fixtures/expected.txt
@@ -42,3 +42,5 @@ Good signature from: Gordon Fontenot (personal) <gordon@fonten.io>
                 aka: Gordon Fontenot (git) <gmoney@gitpushgitpaid.com>
             created: Thu May 12 14:26:06 2016
 [-- End signature information --]
+
+foo bar baz

--- a/fixtures/input.txt
+++ b/fixtures/input.txt
@@ -29,3 +29,5 @@ Good signature from: Gordon Fontenot (personal) <gordon@fonten.io>
                 aka: Gordon Fontenot (git) <gmoney@gitpushgitpaid.com>
             created: Thu May 12 14:26:06 2016
 [-- End signature information --]
+
+foo bar baz

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -55,18 +55,20 @@ quoted :: Parser Content
 quoted = Quoted <$> (quotePrefix *> (quoted <|> normal))
 
 codeBlock :: Parser Content
-codeBlock = do
-    s <- codeBlockChar
-    c <- codeBlockContents
-    e <- codeBlockChar
-    void eol
-    return $ CodeBlock $ s <> c <> e
+codeBlock = fmap CodeBlock
+    $ blockContents codeBlockChar codeBlockContents codeBlockChar
 
 pgpBlock :: Parser Content
-pgpBlock = fmap PGPBlock $ mappend3 <$> pgpBlockStart <*> pgpBlockContents <*> pgpBlockEnd
+pgpBlock = fmap PGPBlock
+    $ blockContents pgpBlockStart pgpBlockContents pgpBlockEnd
 
-mappend3 :: (Monoid m) => m -> m -> m -> m
-mappend3 a b c = a <> b <> c
+blockContents :: Parser Text -> Parser Text -> Parser Text -> Parser Text
+blockContents start contents end = do
+    s <- start
+    c <- contents
+    e <- end
+    void eol
+    return $ s <> c <> e
 
 singleLine :: Parser Text
 singleLine = pack <$> manyTill anyChar (try eol)


### PR DESCRIPTION
Previously, we weren't matching the `eol` at the end of PGP blocks. This meant
that we'd end up adding an additional newline when reconstructing the text. To
fix this, we should make sure we match on that newline.

Additionally, we can actually move _away_ from that mappend3 function and use a
more explicit blockContents function for extracting everything between and
including two sigils, while also removing the newline. I think this is a little
cleaner.
