### PR TITLE
Match whitespace only lines like newlines

### DIFF
--- a/fixtures/input.txt
+++ b/fixtures/input.txt
@@ -3,7 +3,7 @@ To: foo@example.com, bar@example.com, baz@example.com, quz@example.com, foobar@e
 	foobuzz@example.com, fooquz@example.com, bonk@example.com, bink@example.com, bank@example.com, bossman@example.com
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-
+ 
 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
 
 > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -67,11 +67,11 @@ blockContents start contents end = do
     s <- start
     c <- contents
     e <- end
-    void (trailingWhitespace >> eol)
+    void $ trailingWhitespace >> eol
     return $ s <> c <> e
 
 singleLine :: Parser Text
-singleLine = pack <$> manyTill anyChar (try trailingWhitespace >> eol)
+singleLine = pack <$> manyTill anyChar (try $ trailingWhitespace >> eol)
 
 quotePrefix :: Parser Text
 quotePrefix = fmap pack $ mappend


### PR DESCRIPTION
Previously, if there was a whitespace only line, it wouldn't match the eol
parser, and so paragraphs would get squished together. This wasn't intented.
Instead, we should match all whitespace only lines as if they are newlines. I
don't care too much about preserving that whitespace, so this seems reasonable.

This happened a lot with TinyLetter emails, which adds single spaces on every
empty line. Fun stuff.
