### PR TITLE
Preserve leading whitespace for Normal lines

### DIFF
--- a/fixtures/expected.txt
+++ b/fixtures/expected.txt
@@ -25,6 +25,9 @@ in culpa qui officia deserunt mollit anim id est laborum."
 > > veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
 > > commodo consequat.
 
+ - hello
+  - world
+
 ```code
 func Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt {
     ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis

--- a/fixtures/input.txt
+++ b/fixtures/input.txt
@@ -12,6 +12,9 @@ Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu 
 
 > > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
+ - hello
+  - world
+
 ```code
 func Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt {
     ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -24,8 +24,8 @@ wrapContent :: Config -> Content -> [Text]
 wrapContent _ (Blank) = [""]
 wrapContent _ (CodeBlock t) = [t]
 wrapContent _ (PGPBlock t) = [t]
-wrapContent c (Quoted t) = map (mappend "> ") $ wrapContent (lessWidth 2 c) t
-wrapContent c (Normal i t) = map (mappend $ T.pack (replicate i ' ')) $ wrapLine (width c - i) t
+wrapContent c (Quoted t) = mapPrepend "> " $ wrapContent (lessWidth 2 c) t
+wrapContent c (Normal i t) = mapPrepend (emptyText i) $ wrapLine (width c - i) t
 wrapContent c (Header t)
     | ignoreHeaders c = [t]
     | otherwise = wrapLine (width c) t
@@ -42,3 +42,9 @@ splitWordsAt w xs x
 
 appendToLast :: [Text] -> Text -> Text
 appendToLast xs x = T.unwords [last xs, x]
+
+mapPrepend :: Text -> [Text] -> [Text]
+mapPrepend t ts = map (mappend t) ts
+
+emptyText :: Int -> Text
+emptyText i = T.pack $ replicate i ' '

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -24,7 +24,7 @@ wrapContent :: Config -> Content -> [Text]
 wrapContent _ (CodeBlock t) = [t]
 wrapContent _ (PGPBlock t) = [t]
 wrapContent c (Quoted t) = map (mappend "> ") $ wrapContent (lessWidth 2 c) t
-wrapContent c (Normal t) = wrapLine (width c) t
+wrapContent c (Normal i t) = map (mappend $ T.pack (replicate i ' ')) $ wrapLine (width c - i) t
 wrapContent c (Header t)
     | ignoreHeaders c = [t]
     | otherwise = wrapLine (width c) t

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -21,6 +21,7 @@ wrap :: Config -> [Content] -> Text
 wrap c = T.stripEnd . T.unlines . concatMap (wrapContent c)
 
 wrapContent :: Config -> Content -> [Text]
+wrapContent _ (Blank) = [""]
 wrapContent _ (CodeBlock t) = [t]
 wrapContent _ (PGPBlock t) = [t]
 wrapContent c (Quoted t) = map (mappend "> ") $ wrapContent (lessWidth 2 c) t

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -44,7 +44,7 @@ appendToLast :: [Text] -> Text -> Text
 appendToLast xs x = T.unwords [last xs, x]
 
 mapPrepend :: Text -> [Text] -> [Text]
-mapPrepend t ts = map (mappend t) ts
+mapPrepend t = map (mappend t)
 
 emptyText :: Int -> Text
 emptyText i = T.pack $ replicate i ' '

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -9,7 +9,7 @@ import Text.Parsec.Text (Parser)
 import Reflow.Types
 
 parserError :: Text -> ParseError -> Content
-parserError input e = Normal
+parserError input e = Normal 0
     $ input
     <> "\n\n\n"
     <> "Warning: reflow parser failed\n"
@@ -27,7 +27,10 @@ parseContent = do
     return $ h <> c
 
 normal :: Parser Content
-normal = Normal <$> singleLine
+normal = do
+    ws <- many (char ' ')
+    l <- singleLine
+    return $ Normal (length ws) l
 
 header :: Parser Content
 header = do

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -22,7 +22,7 @@ parseFile t = either (return . parserError t) id
 parseContent :: Parser [Content]
 parseContent = do
     h <- option [] (try $ many header)
-    c <- many (quoted <|> try codeBlock <|> try pgpBlock <|> normal)
+    c <- many (blank <|> quoted <|> try codeBlock <|> try pgpBlock <|> normal)
     void eof
     return $ h <> c
 
@@ -31,6 +31,11 @@ normal = do
     ws <- many (char ' ')
     l <- singleLine
     return $ Normal (length ws) l
+
+blank :: Parser Content
+blank = do
+    _ <- try $ trailingWhitespace >> eol
+    return Blank
 
 header :: Parser Content
 header = do

--- a/src/Reflow/Parser.hs
+++ b/src/Reflow/Parser.hs
@@ -34,7 +34,7 @@ normal = do
 
 blank :: Parser Content
 blank = do
-    _ <- try $ trailingWhitespace >> eol
+    void $ try $ trailingWhitespace >> eol
     return Blank
 
 header :: Parser Content

--- a/src/Reflow/Types.hs
+++ b/src/Reflow/Types.hs
@@ -11,5 +11,5 @@ data Config = Config
 lessWidth :: Int -> Config -> Config
 lessWidth i c = c { width = width c - i }
 
-data Content = Normal Int Text | Blank | Header Text | Quoted Content | CodeBlock Text | PGPBlock Text
+data Content = Blank | Normal Int Text | Header Text | Quoted Content | CodeBlock Text | PGPBlock Text
     deriving (Show)

--- a/src/Reflow/Types.hs
+++ b/src/Reflow/Types.hs
@@ -11,5 +11,5 @@ data Config = Config
 lessWidth :: Int -> Config -> Config
 lessWidth i c = c { width = width c - i }
 
-data Content = Normal Text | Header Text | Quoted Content | CodeBlock Text | PGPBlock Text
+data Content = Normal Int Text | Header Text | Quoted Content | CodeBlock Text | PGPBlock Text
     deriving (Show)

--- a/src/Reflow/Types.hs
+++ b/src/Reflow/Types.hs
@@ -11,5 +11,5 @@ data Config = Config
 lessWidth :: Int -> Config -> Config
 lessWidth i c = c { width = width c - i }
 
-data Content = Normal Int Text | Header Text | Quoted Content | CodeBlock Text | PGPBlock Text
+data Content = Normal Int Text | Blank | Header Text | Quoted Content | CodeBlock Text | PGPBlock Text
     deriving (Show)


### PR DESCRIPTION
Sometimes people use leading whitespace for formatting reasons when 
composing plain text emails. It's a shame to have people go through that 
trouble just to have us strip that formatting when we go reflow the text.

To fix this, we can add an indentation level to the Normal constructor, and
take any whitespace we find into account. Then we can indent the whole line
(and all wrapped lines resulting from that line) with the existing
indentation level to maintain formatting.

This actually breaks our existing functionality of treating any
whitespace only lines as a newline, so I also went ahead and refactored
that to be more explicit.